### PR TITLE
when projection is full, expand also returns the time in which the url was shortened

### DIFF
--- a/lib/googl/expand.rb
+++ b/lib/googl/expand.rb
@@ -4,7 +4,7 @@ module Googl
 
     API_URL = "https://www.googleapis.com/urlshortener/v1/url"
 
-    attr_accessor :long_url, :analytics, :status, :short_url
+    attr_accessor :long_url, :analytics, :status, :short_url, :created
 
     # Expands a short URL or gets creation time and analytics. See Googl.expand
     #
@@ -14,6 +14,7 @@ module Googl
 
       resp = Googl::Request.get(API_URL, :query => options)
       if resp.code == 200
+        @created    = resp['created'] if resp.has_key?('created')
         @long_url   = resp['longUrl']
         @analytics  = resp['analytics'].to_openstruct if resp.has_key?('analytics')
         @status     = resp['status']

--- a/spec/expand_spec.rb
+++ b/spec/expand_spec.rb
@@ -60,6 +60,15 @@ describe Googl::Expand do
 
           subject { Googl.expand('http://goo.gl/DWDfi', :projection => :full) }
 
+          describe "#created" do
+            let(:element) { subject.created.to_s }
+
+            it "should be the time url was shortened" do
+              element.should be == '2011-01-13 01:48:10 -0200'
+            end
+
+          end
+
           describe "#all_time" do
             let(:element) { subject.analytics.all_time }
 
@@ -67,7 +76,7 @@ describe Googl::Expand do
             it_should_behave_like 'a period'
 
             it "should rename id to label" do
-              element.countries.first.label.should == "BR" 
+              element.countries.first.label.should == "BR"
             end
           end
 


### PR DESCRIPTION
Hi!

Google url shortener analytics api returns created time when projection is set to full. In this pull request I'm including this feature in googl gem. ;)
