### PR TITLE
Remove implicit ActiveSupport dependency

### DIFF
--- a/lib/googl.rb
+++ b/lib/googl.rb
@@ -24,7 +24,7 @@ module Googl
   #   => "http://goo.gl/ump4S"
   #
   def shorten(url=nil)
-    raise ArgumentError.new("URL to shorten is required") if url.blank?
+    raise ArgumentError.new("URL to shorten is required") if url.nil? || url.strip.empty?
     Googl::Shorten.new(url)
   end
 


### PR DESCRIPTION
String#blank? and NilClass#blank? is added by ActiveSupport and is not available outside of Rails or without explicitly loading AS. There's no need to bring in such a heavy dependency when we can fairly easily approximate #blank?.
