### PR TITLE
Shorten now supports Google's API Key and userIP request parameters.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,6 +14,9 @@ Google URL Shortener API in Ruby
 ``` ruby
 url = Googl.shorten('http://www.zigotto.com')
 
+// Optional - provide a user_ip and your google api_key to bypass Google's request rate limits
+url = Googl.shorten('http://www.zigotto.com', "213.57.23.49", "google_api_key")
+
 url.short_url
 #=> "http://goo.gl/ump4S"
 

--- a/lib/googl.rb
+++ b/lib/googl.rb
@@ -23,9 +23,9 @@ module Googl
   #   url.short_url
   #   => "http://goo.gl/ump4S"
   #
-  def shorten(url=nil)
+  def shorten(url=nil, user_ip = nil, api_key = nil)
     raise ArgumentError.new("URL to shorten is required") if url.nil? || url.strip.empty?
-    Googl::Shorten.new(url)
+    Googl::Shorten.new(url, user_ip, api_key)
   end
 
   # Expands a short URL or gets creation time and analytics

--- a/lib/googl/shorten.rb
+++ b/lib/googl/shorten.rb
@@ -8,10 +8,20 @@ module Googl
 
     # Creates a new short URL, see Googl.shorten
     #
-    def initialize(long_url)
+    def initialize(long_url, user_ip = nil, api_key = nil)
       modify_headers('Content-Type' => 'application/json')
-      options = {"longUrl" => long_url}.to_json
-      resp = post(API_URL, :body => options)
+      options = {"longUrl" => long_url}
+      shorten_url = API_URL
+
+      if (user_ip != nil && !user_ip.empty?)
+        options["userIp"] = user_ip
+      end
+      if (api_key != nil && !api_key.empty?)
+        shorten_url += "?key=#{api_key}"
+      end
+
+      options_json = options.to_json
+      resp = post(shorten_url, :body => options_json)
       if resp.code == 200
         self.short_url  = resp['id']
         self.long_url   = resp['longUrl']

--- a/spec/googl/shorten_spec.rb
+++ b/spec/googl/shorten_spec.rb
@@ -53,6 +53,36 @@ describe Googl::Shorten do
 
     end
 
+    context "with user_ip" do
+      subject { Googl.shorten('http://www.zigotto.com', "54.154.97.74") }
+
+      describe "#short_url" do
+        it "should return a short URL" do
+          subject.short_url.should == 'http://goo.gl/ump4S'
+        end
+      end
+    end
+
+    context "with api_key" do
+      subject { Googl.shorten('http://www.zigotto.com', nil, "Abc123") }
+
+      describe "#short_url" do
+        it "should return a short URL" do
+          subject.short_url.should == 'http://goo.gl/ump4S'
+        end
+      end
+    end
+
+    context "with user_ip and api_key" do
+      subject { Googl.shorten('http://www.zigotto.com', nil, "Abc123") }
+
+      describe "#short_url" do
+        it "should return a short URL" do
+          subject.short_url.should == 'http://goo.gl/ump4S'
+        end
+      end
+    end
+
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,30 @@ def fake_urls?(status)
       with(:body => params).
       to_return(load_fixture('shorten_invalid_content_type.json'))
 
+    # Shorten with user_ip
+    url_shorten = "https://www.googleapis.com/urlshortener/v1/url"
+    params = "{\"longUrl\":\"http://www.zigotto.com\",\"userIp\":\"54.154.97.74\"}" #json
+    stub_request(:post, url_shorten).
+        with(:body => params,
+             :headers => {'Content-Type'=>'application/json'}).
+        to_return(load_fixture('shorten.json'))
+
+    # Shorten with api_key
+    url_shorten_with_key = "https://www.googleapis.com/urlshortener/v1/url?key=Abc123"
+    params = "{\"longUrl\":\"http://www.zigotto.com\"}" #json
+    stub_request(:post, url_shorten_with_key).
+        with(:body => params,
+             :headers => {'Content-Type'=>'application/json'}).
+        to_return(load_fixture('shorten.json'))
+
+    # Shorten with user_ip and api_key
+    url_shorten_with_key = "https://www.googleapis.com/urlshortener/v1/url?key=Abc123"
+    params = "{\"longUrl\":\"http://www.zigotto.com\",\"userIp\":\"54.154.97.74\"}" #json
+    stub_request(:post, url_shorten_with_key).
+        with(:body => params,
+             :headers => {'Content-Type'=>'application/json'}).
+        to_return(load_fixture('shorten.json'))
+
     # Expand
     url_expand = "https://www.googleapis.com/urlshortener/v1/url?shortUrl=http://goo.gl/7lob"
     stub_request(:get, url_expand).to_return(load_fixture('expand.json'))


### PR DESCRIPTION
Used to bypass Google's request rate limits.
Tests might need some refactoring but should be good enough for now.