### PR TITLE
Add a specific class for Googl error for better handling when using the gem

### DIFF
--- a/lib/googl.rb
+++ b/lib/googl.rb
@@ -2,6 +2,7 @@ require 'httparty'
 require 'ostruct'
 require 'json'
 
+require 'googl/error'
 require 'googl/utils'
 require 'googl/base'
 require 'googl/request'

--- a/lib/googl/error.rb
+++ b/lib/googl/error.rb
@@ -1,0 +1,4 @@
+module Googl
+  class Error < StandardError
+  end
+end

--- a/lib/googl/utils.rb
+++ b/lib/googl/utils.rb
@@ -22,7 +22,7 @@ module Googl
     end
 
     def exception(msg)
-      Exception.new(msg)
+      Googl::Error.new(msg)
     end
 
   end


### PR DESCRIPTION
Fixes #18 
One can now use
````ruby
begin
   Googl.shorten(...)
rescue Googl::Error => e
  ...
end
````
to rescue only from Googl error.